### PR TITLE
Add support for `templateProvider` in @State configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ So, if you like the clean syntax of Angular 2, but are not yet ready or able to 
 **NPM**
 
     npm install angular2-now
-    
+
 **BOWER**
 
     bower install angular2-now
@@ -26,11 +26,11 @@ So, if you like the clean syntax of Angular 2, but are not yet ready or able to 
 ```html
 <!-- Meteor 1.2 -->
 <script src="https://npmcdn.com/angular2-now@1.0.0/angular2-now.js"></script>
- 
+
 <!-- Meteor 1.1 -->
 <script src="https://npmcdn.com/angular2-now@0.3.15/angular2-now.js"></script>
 ```
-    
+
 ## Usage with ES6
 
 Use angular2-now with an **ES6 transpiler** like **Babel** or **TypeScript**. Both work equally well.
@@ -38,9 +38,9 @@ Use angular2-now with an **ES6 transpiler** like **Babel** or **TypeScript**. Bo
 Include angular2-now in your AngularJS project, ensuring that it loads before any of it's functions are used. If you're not using any module loaders, then `window.angular2now` gives you direct access to all the annotation functions.
 
 > See the **Examples and Demos** section below for examples.
- 
+
 ### With SystemJS
- 
+
 If your app loads SystemJS before angular2-now, then angular2-now will register itself with SystemJS and you will be able to import annotations as shown below.
 
 ```javascript
@@ -54,22 +54,22 @@ With Meteor 1.2 you will be using `angular2-now` in combination with `angular-me
 #### Meteor and SystemJS module loader
 
 SystemJS support is provided by adding the package `pbastowski:systemjs` to your project. Make sure to read the [README](https://github.com/pbastowski/angular-meteor-babel/tree/meteor1.2) for `pbastowski:angular-babel` to understand:
-- how to enable SystemJS support and 
+- how to enable SystemJS support and
 - how `angular-babel` names SystemJS modules in your project
 
-Otherwise, you might have trouble importing from them. 
+Otherwise, you might have trouble importing from them.
 
 #### Meteor without SystemJS (the old way)
 
 Meteor does not need any kind of module loader, because it bundles and loads your files according to its [convention](http://docs.meteor.com/#/full/fileloadorder). This may be enough for you, if you're happy to use angular2-now through the globally visible `window.angular2now` object.
-  
+
 On the other hand, if you like to use ES6 `import ... from` statements in your project and don't want to use SystemJS, then add the package `pbastowski:require` to your project. It provides basic `module.exports` functionality in the browser and will allow you to export like this
 
 **MyService.js**
 
 ```javascript
 export class MyService { }
- 
+
 export var things = {
     thing1,
     thing2
@@ -83,12 +83,12 @@ And import like this
 ```javascript
 import "MyService";
 
-import {thing1} from "things"    
+import {thing1} from "things"
 ```
 
-> When using `pbastowski:require` individual objects are exported by their name. There is no concept of a module, as such. Think of exporting as making the object global. In fact you can also access the exported object through `window.things` or `window.MyService`. 
+> When using `pbastowski:require` individual objects are exported by their name. There is no concept of a module, as such. Think of exporting as making the object global. In fact you can also access the exported object through `window.things` or `window.MyService`.
 
-In the above example, when we `import "MyService"` we are actually importing the whole class object, whereas `thing1` is the only object imported from `things`. 
+In the above example, when we `import "MyService"` we are actually importing the whole class object, whereas `thing1` is the only object imported from `things`.
 
 ## Which Angular 2 annotations can I use in my Angular 1 apps?
 
@@ -97,8 +97,8 @@ The following annotations have been implemented to support Angular 2.0 component
 ```javascript
 SetModule('my-app', ['angular-meteor']);  // Use SetModule in place of angular.module
 
-@Component({ 
-    selector: 'my-app', 
+@Component({
+    selector: 'my-app',
     ?bind: { twoWay: '=', value: '@', function: '&' },
     ?services: ['$http', '$q', 'myService'],
     ?replace: true or false,
@@ -106,8 +106,8 @@ SetModule('my-app', ['angular-meteor']);  // Use SetModule in place of angular.m
     ?scope: undefined or true or same as bind
 })
 
-@View({ 
-    template: '<div>Inline template</div>',    // inline template 
+@View({
+    template: '<div>Inline template</div>',    // inline template
     templateUrl: 'path/to/the_template.html',  // importing a template
     ?transclude: true or false
 })
@@ -122,34 +122,35 @@ class App {
 bootstrap(App, ?config);  // config is optional
 ```
 
-The annotations below are not Angular 2, but for me they make coding in Angular a bit nicer. 
+The annotations below are not Angular 2, but for me they make coding in Angular a bit nicer.
 
 ```javascript
 @Service({ name: 'serviceName' })
- 
+
 @Filter({ name: 'filterName' })
- 
+
 @Directive()     // alias for @Component
- 
+
 @ScopeShared()  // same as { scope: undefined } on @Directive
- 
-@ScopeNew()     // same as { scope: true } on @Directive 
+
+@ScopeNew()     // same as { scope: true } on @Directive
 ```
 
 Client-side routing with ui-router
 ```javascript
 @State({
-    name: 'stateName', 
-    ?url: '/stateurl', 
+    name: 'stateName',
+    ?url: '/stateurl',
     ?defaultRoute: true/false or '/default/route/url',
     ?abstract: true or false,
     ?html5Mode: true/false,
     ?params: { id: 123 },  // default params, see ui-router docs
     ?data: { a: 1, b: 2},  // custom data
-    ?resolve: {...}, 
-    ?controller: controllerFunction, 
+    ?resolve: {...},
+    ?controller: controllerFunction,
     ?template: '<div></div>',
     ?templateUrl: 'client/app/app.html',
+    ?templateProvider: function ($stateParams) { return '<h1>' + $stateParams.contactId + '</h1>'; }
 }))
 ```
 
@@ -185,11 +186,11 @@ Please visit the following github repositories and Plunker examples before you s
 `Directive` is an alias for `Component`, which means it does the same thing, but is spelled different. The main difference between directives and components is that directives have no template HTML. A Directive is an attribute on an existing HTML element that simply adds new behaviour to that element. It is one attribute amongst any number of other attributes on an element.
 
 There is an implication to this, in that AngularJS only allows one directive to have isolate scope on the same HTML element. By default, `Component` creates isolate scope and since `Directive` is an alias for `Component` it also creates isolate scope. This sometimes causes issues.
- 
- To overcome that, you can use a couple of annotations: 
+
+ To overcome that, you can use a couple of annotations:
  - `ScopeShared` same as passing `{ scope: undefined }` to `@Directive`
  - `ScopeNew` same as passing `{ scope: true }` to `@Directive`
- 
+
  ```javascript
 @Directive({ ... })
 @ScopeShared()
@@ -203,7 +204,7 @@ SetModule( 'app', ['angular-meteor', 'ui.router', 'my-other-module'] )
 ```
 
 You must use `SetModule` at least once in your app, before you use any annotations, to tell angular2-now in which module to create all Components, Services, Filters and State configuration. The syntax is identical to Angular's own [angular.module()](https://docs.angularjs.org/api/ng/function/angular.module). Use `SetModule` in the same places you would normally use `angular.module`.
-  
+
 ### ui-router support through @State
 
 This is completely not Angular 2, but I love how easy it makes my routing. You'll have to include ui-router in your app
@@ -211,16 +212,16 @@ This is completely not Angular 2, but I love how easy it makes my routing. You'l
 Meteor:
 
     meteor add angularui:angular-ui-router
-    
+
 Bower:
 
     bower install angular-ui-router
 
 And then add the `ui.router` dependency to your bootstrap module, like this
-  
+
     SetModule('myApp', ['angular-meteor', 'ui.router']);
 
-Then, you can simply annotate your component with the route/state info, like so 
+Then, you can simply annotate your component with the route/state info, like so
 
 ```javascript
 @State({name: 'defect', url: '/defect', defaultRoute: true})
@@ -228,7 +229,7 @@ Then, you can simply annotate your component with the route/state info, like so
 @Component({selector: 'defect'})
 @View({templateUrl: 'client/defect/defect.html'})
 @Inject(['lookupTables'])
-class Defect { 
+class Defect {
 }
 ```
 
@@ -241,9 +242,9 @@ class Defect {
 { name: 'root.defect',        url: '/defect', defaultRoute: true }
 ```
 
-The `defaultRoute` property makes the annotated state the default for your app. That is, if the user types an unrecognised path into the address bar, or does not type any path other than the url of your app, they will be redirected to the path specified in defaultRoute. It is a bit like the old 404 not found redirect, except that in single page apps there is no 404. There is just the default page (or route). 
+The `defaultRoute` property makes the annotated state the default for your app. That is, if the user types an unrecognised path into the address bar, or does not type any path other than the url of your app, they will be redirected to the path specified in defaultRoute. It is a bit like the old 404 not found redirect, except that in single page apps there is no 404. There is just the default page (or route).
 
-> Meteor's web server automatically redirects all unrecognised routes to the app root "/". However, if you're not using Meteor, you'll want to make sure that all unrecognised routes are redirected to the app root, which in many cases is "/". 
+> Meteor's web server automatically redirects all unrecognised routes to the app root "/". However, if you're not using Meteor, you'll want to make sure that all unrecognised routes are redirected to the app root, which in many cases is "/".
 
 Note that `defaultRoute: true` only works when the state's `url` is the same as it's defaultRoute.
 
@@ -253,12 +254,12 @@ For example
 { name: 'root.defect', url: '/defect', defaultRoute: '/defect' }
 ```
 
-can be replaced with 
+can be replaced with
 
 ```javascript
 { name: 'root.defect', url: '/defect', defaultRoute: true }
 ```
- 
+
 For nested states, where the default state has parent states with their own URLs, always specify the `defaultRoute` as a string that represents the final URL that you want the app to navigate to by default.
 
 #### Resolving Values
@@ -267,8 +268,8 @@ A `ui-router` resolve block can be added to the @State annotation, as shown belo
 
 ```javascript
 @State({
-    name: 'defect', 
-    url: '/defect', 
+    name: 'defect',
+    url: '/defect',
     defaultRoute: true,
     resolve: {
         user: ['$q', function($q) { return 'paul'; }],
@@ -281,7 +282,7 @@ A `ui-router` resolve block can be added to the @State annotation, as shown belo
 @Inject('defect')
 
 class Defect {
-    constructor(defect) { 
+    constructor(defect) {
         // defect.name == 'paul'
         // defect.role == 'admin'
     }
@@ -294,21 +295,21 @@ Read on for how to inject the resolved values into your component's controller.
 
 ####  Injecting Resolved Dependencies into your component's controller
 
-The resolved values are made available for injection into a component's constructor, as shown in the example above. The injected parameter `defect` is the name of a service automatically created for you, which holds the resolved return values. The name of this service is always the camelCased version of your component's selector. So, if the selector == 'my-app', then the name of the injectable service will be 'myApp'. 
+The resolved values are made available for injection into a component's constructor, as shown in the example above. The injected parameter `defect` is the name of a service automatically created for you, which holds the resolved return values. The name of this service is always the camelCased version of your component's selector. So, if the selector == 'my-app', then the name of the injectable service will be 'myApp'.
 
 
 #### States without a component
-    
+
 It is also possible to define a state without a component, as shown below, provided that you do not also annotate it's Class as a Component.
 
 ```javascript
-@State({ 
-    name: 'test', 
-    url: '/test', 
-    resolve: { 
+@State({
+    name: 'test',
+    url: '/test',
+    resolve: {
         user: function() { return 'paul'; },
-        role: function() { return 'admin'; } 
-    } 
+        role: function() { return 'admin'; }
+    }
 })
 class App {
     constructor(user, role) {
@@ -317,18 +318,18 @@ class App {
 }
 ```
 
-In this case, the class constructor is the controller for the route and receives the injected properties directly (as per ui-router documentation).  
+In this case, the class constructor is the controller for the route and receives the injected properties directly (as per ui-router documentation).
 
 ### Bootstrapping the app
 
-This allows you to bootstrap your Angular 1 app using the Angular 2 component bootstrap syntax. There is no need to use `ng-app`. 
+This allows you to bootstrap your Angular 1 app using the Angular 2 component bootstrap syntax. There is no need to use `ng-app`.
 
 ```javascript
 bootstrap (App [, config ])
-``` 
+```
 
 Using `bootstrap` is the equivalent of the Angular 1 manual bootstrapping method: `angular.bootstrap(DOMelement, ['app'])`. The bootstrap function also knows how to handle Cordova apps.
-`config` is the same parameter as in [angular.bootstrap()](https://code.angularjs.org/1.3.15/docs/api/ng/function/angular.bootstrap). It can be used to enforce strictDi, for testing before deployment to production. 
+`config` is the same parameter as in [angular.bootstrap()](https://code.angularjs.org/1.3.15/docs/api/ng/function/angular.bootstrap). It can be used to enforce strictDi, for testing before deployment to production.
 
 #### An example showing how to bootstrap an app
 
@@ -338,14 +339,14 @@ In your HTML body add this:
 <my-app>Optional content inside my app that can be transcluded</my-app>
 ```
 
-And in your JavaScript add the code below.  
+And in your JavaScript add the code below.
 
 ```javascript
 SetModule('my-app', []);
 
 @Component({selector: 'my-app' })
 @View({template: `<content></content>`})
-class App { 
+class App {
 }
 
 bootstrap(App);
@@ -367,7 +368,7 @@ Sure. If you want to use `vm` as the controller name for a specific component, t
 
 ```javascript
 @Component({ selector: 'defect', controllerAs: 'vm' })
-class Defect { 
+class Defect {
     test() {}
 }
 ```
@@ -391,23 +392,23 @@ Do this before you use any angular2-now components!
 
 
 ### Transclusion
- 
+
 #### Inline templates
- 
+
 If your inline `template` includes `<content></content>` then `@View` will automatically add `ng-transclude` to it and internally the directive's `transclude` flag will be set to `true`.
 
 So, this inline HTML template
 
 ```html
 h2 This is my header
-<content></content>  
+<content></content>
 ```
 
-will be automatically changed to look like this 
+will be automatically changed to look like this
 
 ```html
 h2 This is my header
-<content ng-transclude></content>  
+<content ng-transclude></content>
 ```
 
 #### `templateUrl` and transclusion
@@ -420,17 +421,17 @@ Templates specified using the `templateUrl` property aren't currently checked an
 
 ### How do I access `ngModel` and other component's controllers?
 
-You `@Inject` the names of the components whose controllers you want. Prefix each controller name with `"@"` or `"@^"` (looks for a parent controller). These dependencies are not directly injected into the constructor (controller), because they are not available at the time the constructor executes, but at `link` time (see AngularJS documentation about this). However, they can be accessed within the constructor like this: 
+You `@Inject` the names of the components whose controllers you want. Prefix each controller name with `"@"` or `"@^"` (looks for a parent controller). These dependencies are not directly injected into the constructor (controller), because they are not available at the time the constructor executes, but at `link` time (see AngularJS documentation about this). However, they can be accessed within the constructor like this:
 
 ```javascript
 @Component({ selector: 'tab' })
 @Inject('@ngModel', '@^tabContainer')
 class Tab {
     constructor() {
-    
+
         this.$dependson = function (ngModel, tabContainer) {
             ngModel.$parsers.unshift(function (value) { ... });
-            
+
             // This gives you access to tabContainer's scope methods and properties
             tabContainer.someFunction();
             if (tabContainer.tabCount === 0) { ... }
@@ -447,7 +448,7 @@ Below is the list of angular2-now options that can be changed.
 
 Attribute | Type | Description
 ----------|------|-------------------
-controllerAs | string | Allows you to specify a default controllerAs prefix to use for all components. The default prefix is the camel-cased version of the component's selector.   
+controllerAs | string | Allows you to specify a default controllerAs prefix to use for all components. The default prefix is the camel-cased version of the component's selector.
 spinner	| object | Exposes show() and hide() methods, that show and hide a busy-spinner
 events	| object | Exposes beforeCall() and afterCall(), which will be called before and after the ajax call. Only `afterCall` is guaranteed to run after the call to the MeteorMethod completes.
 
@@ -497,7 +498,7 @@ Meteor.methods({
 ```
 
 On the client side, you annotate a stub method, in this case `sendEmail(){}`, in your `Service` or `Component` class with `@MeteorMethod()`. The name of the stub method must be the same as the name of the Meteor method on the server:
- 
+
 ```javascript
 class Mail {
    @MeteorMethod()
@@ -533,7 +534,7 @@ sendEmail() {}
 - `angular.module` is no longer monkey-patched by angular2-now. You must use `SetModule` instead of `angular.module` for all modules where you wish to use angular2-now. SetModule has the exact same syntax as angular.module. This change was necessary due to problems encountered with the monkey-patching approach under certain conditions.
 
 ## What environment is required?
-- Angular 1.4+ 
+- Angular 1.4+
 - Babel 5.1.10+
 - Meteor 1.2+
 
@@ -552,8 +553,8 @@ Then you may want to have a look at [ng-forward](https://github.com/ngUpgraders/
 The short answer is no, because I designed `angular2-now` for a specific purpose with narrow requirements:
 
 - make Angular 1 coding simple and fun for myself and my team
-- make me think of web apps in terms of components within components, instead of HTML + controllers + directives + ui-router 
-- make ui-router configuration simple (because it is not) 
+- make me think of web apps in terms of components within components, instead of HTML + controllers + directives + ui-router
+- make ui-router configuration simple (because it is not)
 
 As it stands now, the above three requirements are satisfied for myself, but if you would like to contribute then I am happy to consider a PR.
 

--- a/angular2-now.js
+++ b/angular2-now.js
@@ -434,17 +434,20 @@ var angular2now = function () {
      * a ui-router state to it.
      *
      * @param options   literal object
-     *      name:           name of the state
-     *      url:            url associated with this state
-     *      template:       template
-     *      templateUrl:    templateUrl
-     *      defaultRoute:   truthy = .otherwise(url)
-     *                      string = .otherwise(defaultRoute)
-     *      resolve:        Literal object, see ui-router resolve
-     *      abstract:       true/false
-     *      params:         Literal object, see ui-router doco
-     *      controller:     A controller is automatically assigned, but if you need
-     *                      finer control then you can assign your own controller
+     *      name:              name of the state
+     *      url:               url associated with this state
+     *      template:          template
+     *      templateUrl:       templateUrl
+     *      templateProvider:  templateProvider
+     *      defaultRoute:      truthy = .otherwise(url)
+     *                         string = .otherwise(defaultRoute)
+     *      resolve:           Literal object, see ui-router resolve
+     *      abstract:          true/false
+     *      params:            Literal object, see ui-router doco
+     *      controller:        A controller is automatically assigned, but if you need
+     *                         finer control then you can assign your own controller
+     *      controllerAs:      Specify ControllerAs for cases when there is no
+     *                         @Component used
      *
      * If a class is annotated then it is assumed to be the controller and
      * the state name will be used as the name of the injectable service
@@ -457,7 +460,7 @@ var angular2now = function () {
     function State(options) {
 
         if (!options || !(options instanceof Object) || options.name === undefined)
-            throw new Error('@State: Valid options are: name, url, defaultRoute, template, resolve, abstract, data.');
+            throw new Error('@State: Valid options are: name, url, defaultRoute, template, templateUrl, templateProvider, resolve, abstract, data.');
 
         return function (target) {
 
@@ -537,6 +540,10 @@ var angular2now = function () {
                             //     be rendered again by ui-router, or you will literally see it twice.
                             // todo: allow the user to specify their own div/span instead of forcing "div(ui-view)"
                             template: options.templateUrl ? undefined : options.template || ((target.template || target.templateUrl) && !target.bootstrap && target.selector ? target.selector.replace(/^(.*)$/, '<$1></$1>') : '<div ui-view=""></div>'),
+
+                            // The option for dynamically setting a template based on local values
+                            //  or injectable services
+                            templateProvider: options.templateProvider,
 
                             // Do we need to resolve stuff? If so, then we also provide a controller to catch the resolved data.
                             resolve:    resolves,


### PR DESCRIPTION
Adding support for the ui-router 'templateProvider' state configuration
option. Useful for cases when the template should be set dynamically.
