### PR TITLE
fix(MeteorMethod): overwriting local options

### DIFF
--- a/angular2-now.js
+++ b/angular2-now.js
@@ -646,7 +646,7 @@ var angular2now = function () {
 
     // The name of the Meteor.method is the same as the name of class method.
     function MeteorMethod(_options) {
-        var options = angular.merge({}, _options, ng2nOptions);
+        var options = angular.merge({}, ng2nOptions, _options);
         var spinner = options.spinner || {show: angular.noop, hide: angular.noop};
         var events = options.events || {beforeCall: angular.noop, afterCall: angular.noop};
 


### PR DESCRIPTION
When MeteorMethod decorator has its own options and global options (ng2nOptions) have been set and there is the property with the same name, it will be overwritten.

Options are in wrong order.
